### PR TITLE
Fix documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ Microsleep and drowsiness detection for drivers using Raspberry Pi 4. Uses openC
 
 ## Follow Us!
 [Check out our Linktree](https://linktr.ee/wakeomatic) for all of our social medias!
-[Visit our documentation](https://github.com/Hamlob/wake-o-matic/wiki) to learn how to use the project.
+
+[Visit our documentation](https://hamlob.github.io/wake-o-matic/) to learn how to use the project.
 
 ## About the Project
 Driving while drowsy is a danger that all of us are aware of, however most of us can probably think of an example of a time we took the risk in order to get to our destination. [According to road safety charity, Brake](https://www.brake.org.uk/get-involved/take-action/mybrake/knowledge-centre/driver-fatigue#:~:text=Worldwide%2C%20it%20is%20estimated%20that,road%20crashes%20are%20fatigue%2Drelated.), 1 in 8 drivers admit to falling asleep at the wheel, with an estimated 10-20% of UK traffic accidents being fatigue related.


### PR DESCRIPTION
Small mistake in README where the link was outdated and newline character wasn't registered